### PR TITLE
fix: serverless start command, move api flags to compose

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -34,6 +34,10 @@ When adding new environment variables:
 - Prefix model-specific settings with `MODEL_`
 - Provide sane defaults or `None` to let vLLM handle it
 
+## Model Agnosticism
+
+Juno Handler is model-agnostic. Please, never assume users are running any specific model, model family, or model type. Code and documentation should work for any vLLM-compatible model.
+
 ## AI Contribution Honesty Policy
 
 While I think headless coding agents are silly, I do welcome AI-generated code, issues, and PRs. 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ COPY pyproject.toml uv.lock ./
 RUN uv sync --no-dev
 
 COPY juno ./juno
-CMD ["python", "-m", "juno.handler", "--rp_serve_api", "--rp_api_host", "0.0.0.0"]
+CMD ["python", "-m", "juno.handler"]

--- a/README.md
+++ b/README.md
@@ -114,18 +114,32 @@ response = client.chat.completions.create(
 **Required:**
 - `MODEL_NAME` - HuggingFace model identifier
 
-**Optional model settings:**
-- `MODEL_QUANTIZATION` - awq, gptq, fp8 (valid vLLM arguments)
-- `MODEL_MAX_LEN` - Maximum context length in tokens (controls KV cache allocation)
-- `MODEL_TOKENIZER`, `MODEL_CONFIG_FORMAT`, `MODEL_LOAD_FORMAT` - only if your model needs them/vllm can't guess it
+**Model settings:**
+- `MODEL_DTYPE` - Data type (`float16`, `bfloat16`, `auto`, etc.)
+- `MODEL_QUANTIZATION` - Quantization method (`awq`, `gptq`, `fp8`)
+- `MODEL_TRUST_REMOTE_CODE` - Allow custom model code (`true`, `1`, `yes` to enable)
+- `MODEL_TOKENIZER` - Tokenizer mode (default: `auto`)
+- `MODEL_CONFIG_FORMAT` - Config format (default: `auto`)
+- `MODEL_LOAD_FORMAT` - Load format (default: `auto`)
 
-**Generation settings:**
+**Limits:**
+- `MODEL_MAX_LEN` - Maximum context length in tokens
+- `MODEL_MAX_NUM_SEQS` - Maximum sequences per iteration
+
+**Generation defaults:**
 - `MODEL_TEMPERATURE` (default: 0.15)
-- `MAX_SAMPLING_TOKENS` (default: 32768)
-- `TOP_P` (default: 0.95)
+- `MODEL_MAX_TOKENS` (default: 32768)
+- `MODEL_TOP_P` (default: 0.95)
 
 **Runtime:**
-- `GPU_MEMORY_UTILIZATION` (default: 0.9)
+- `GPU_MEMORY_UTILIZATION` (default: 0.8)
+- `DISTRIBUTED_EXECUTOR_BACKEND` - Execution backend (`ray`, `mp`, `uni`)
+
+**(Optional) Cache persistence:**
+- `TORCH_HOME` - PyTorch cache directory (e.g. `/runpod-volume/.cache/torch`)
+- `HF_HOME` - HuggingFace cache directory (e.g. `/runpod-volume/.cache/huggingface`)
+
+Setting these to a network volume path persists compiled extensions and model weights across worker restarts, reducing cold start times.
 
 ## Models
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,10 @@
 services:
   test:
     build: .
+    command: ["python", "-m", "juno.handler", "--rp_serve_api", "--rp_api_host", "0.0.0.0"]
     environment: # I have a 3070, so we're not testing on a very large model and enable a lower memory utilization.
       - MODEL_NAME=unsloth/Qwen3-4B
+      - MODEL_MAX_LEN=4096
       - GPU_MEMORY_UTILIZATION=0.8
     ports:
       - "8000:8000"

--- a/juno/handler.py
+++ b/juno/handler.py
@@ -125,6 +125,5 @@ if __name__ == '__main__':
         gpu_memory_utilization=float(os.getenv("GPU_MEMORY_UTILIZATION") or "0.8"),
     )
 
-    
-
+    runpod.serverless.start({"handler": handler})
     runpod.serverless.start({"handler": handler})

--- a/juno/handler.py
+++ b/juno/handler.py
@@ -1,5 +1,6 @@
 import os
 import re
+import sys
 import time
 import uuid
 
@@ -11,15 +12,20 @@ from vllm import LLM, SamplingParams
 from juno.schema import VALIDATIONS
 
 MODEL = os.getenv("MODEL_NAME")
+DTYPE = os.getenv("MODEL_DTYPE")
+QUANTIZATION = os.getenv("MODEL_QUANTIZATION")
+TRUST_REMOTE_CODE = os.getenv("MODEL_TRUST_REMOTE_CODE", "").lower() in ("true", "1", "yes")
 TOKENIZER = os.getenv("MODEL_TOKENIZER")
 CONFIG_FORMAT = os.getenv("MODEL_CONFIG_FORMAT")
 LOAD_FORMAT = os.getenv("MODEL_LOAD_FORMAT")
-QUANTIZATION = os.getenv("MODEL_QUANTIZATION")
+
 MAX_MODEL_LEN = int(os.getenv("MODEL_MAX_LEN")) if os.getenv("MODEL_MAX_LEN") else None
+MAX_NUM_SEQS = int(os.getenv("MODEL_MAX_NUM_SEQS")) if os.getenv("MODEL_MAX_NUM_SEQS") else None
+DISTRIBUTED_EXECUTOR_BACKEND = os.getenv("DISTRIBUTED_EXECUTOR_BACKEND")
 
 DEFAULT_TEMPERATURE = float(os.getenv("MODEL_TEMPERATURE") or "0.15")
-DEFAULT_MAX_TOKENS = int(os.getenv("MAX_SAMPLING_TOKENS") or "32768")
-DEFAULT_TOP_P = float(os.getenv("TOP_P") or "0.95")
+DEFAULT_MAX_TOKENS = int(os.getenv("MODEL_MAX_TOKENS") or "32768")
+DEFAULT_TOP_P = float(os.getenv("MODEL_TOP_P") or "0.95")
 
 model = None
 
@@ -100,7 +106,7 @@ def handler(job):
 if __name__ == '__main__':
     if not MODEL:
         print("Define a MODEL_NAME...")
-        os._exit(-1)
+        sys.exit(-1)
 
     log.info("Loading {}...".format(MODEL))
 
@@ -111,8 +117,14 @@ if __name__ == '__main__':
         load_format=LOAD_FORMAT or "auto",
         quantization=QUANTIZATION,
         max_model_len=MAX_MODEL_LEN,
+        dtype=DTYPE or "auto",
+        trust_remote_code=TRUST_REMOTE_CODE,
+        max_num_seqs=MAX_NUM_SEQS,
+        distributed_executor_backend=DISTRIBUTED_EXECUTOR_BACKEND,
         tensor_parallel_size=int(os.getenv("RUNPOD_GPU_COUNT") or "1"),
         gpu_memory_utilization=float(os.getenv("GPU_MEMORY_UTILIZATION") or "0.8"),
     )
+
+    
 
     runpod.serverless.start({"handler": handler})

--- a/juno/handler.py
+++ b/juno/handler.py
@@ -106,7 +106,7 @@ def handler(job):
 if __name__ == '__main__':
     if not MODEL:
         print("Define a MODEL_NAME...")
-        sys.exit(-1)
+        sys.exit(1)
 
     log.info("Loading {}...".format(MODEL))
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR adds new vLLM configuration options and fixes the serverless deployment architecture. The Dockerfile CMD now only starts the handler without API flags, while `docker-compose.yml` includes the API flags for local testing. This separation is correct for serverless deployments where the API server is managed by the Runpod platform.

- Added control levers for `dtype`, `trust_remote_code`, `max_num_seqs`, and `distributed_executor_backend`
- Moved `--rp_serve_api` and `--rp_api_host` flags from Dockerfile to docker-compose testing configuration
- Updated environment variable names for consistency (`MODEL_MAX_TOKENS`, `MODEL_TOP_P`)
- Changed `os._exit(-1)` to `sys.exit(-1)` for cleaner shutdown
- Updated documentation to reflect new configuration options and defaults

The changes follow the codebase patterns of using module-level environment variables with defaults, maintaining model agnosticism, and keeping the handler minimal.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minor style improvements recommended
- The changes are straightforward configuration additions and architectural improvements. The separation of API flags from production to testing is correct. Only minor style issues exist (trailing whitespace and exit code convention)
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| juno/handler.py | Added new vLLM config options (dtype, trust_remote_code, max_num_seqs, distributed_executor_backend); changed os._exit to sys.exit; minor style issues with trailing whitespace |
| docker-compose.yml | Moved API server flags from Dockerfile to compose command for testing; added MODEL_MAX_LEN environment variable |
| Dockerfile | Removed API flags from default CMD, simplifying the production image (flags now only in test compose) |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->