### PR TITLE
fix: set correct finish_reason for tool calls, conditionally include reasoning_content

### DIFF
--- a/juno/handler.py
+++ b/juno/handler.py
@@ -103,10 +103,11 @@ def handler(job):
 
     message = {
         "role": "assistant",
-        "reasoning_content": reasoning_content,
         "content": text,
     }
 
+    if reasoning_content:
+        message["reasoning_content"] = reasoning_content
     if tool_calls:
         message["tool_calls"] = tool_calls
 
@@ -118,7 +119,7 @@ def handler(job):
         "choices": [{
             "index": 0,
             "message": message,
-            "finish_reason": output.finish_reason,
+            "finish_reason": "tool_calls" if tool_calls else output.finish_reason,
         }],
         "usage": {
             "prompt_tokens": len(result.prompt_token_ids or []),


### PR DESCRIPTION
This PR fixes two bugs in tool call response formatting that break multi-turn agentic workflows.

- Override `finish_reason` to return `"tool_calls"` when `tool_calls` are present, matching OpenAI API contract (vLLM always returns `"stop"`)
- Only include `reasoning_content` in the message dict when it has a value, preventing `null` from leaking into conversation history and causing vLLM rejection in subsequent turns

Both changes align the conditional field inclusion pattern with `tool_calls`.

<a href="https://capy.ai/project/89dbedd7-ecec-4a51-b9f4-42aaaac71811/pull/8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/89dbedd7-ecec-4a51-b9f4-42aaaac71811/task/5dd18b4d-7575-4156-98a5-fa823535c307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=claude-opus-4-6&task=JUN-1&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=claude-opus-4-6&task=JUN-1"><img alt="JUN-1 · Opus 4.6" src="https://capy.ai/api/badge/task.svg?model=claude-opus-4-6&task=JUN-1"></picture></a>